### PR TITLE
Dev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .terraform*
+terraform.tfstate*
 .vscode*
 variables.tfvars

--- a/main.tf
+++ b/main.tf
@@ -33,6 +33,9 @@ resource "docker_image" "jenkins_latest" {
 
 resource "docker_volume" "jenkins_volume" {
   name = "jenkins_data"
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 data "docker_registry_image" "transmission_image" {
@@ -46,6 +49,9 @@ resource "docker_image" "transmission_latest" {
 
 resource "docker_volume" "transmission_config" {
   name = "transmission_config"
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 resource "docker_volume" "transmission_watch" {
@@ -54,16 +60,15 @@ resource "docker_volume" "transmission_watch" {
 
 resource "docker_container" "rproxy_container" {
   name = "rproxy"
-  image = docker_image.rproxy_latest.id
+  image = docker_image.rproxy_latest.name
   restart = "always"
   volumes {
     host_path = var.ssl_certs
     container_path = "/etc/nginx/certs"
-    volume_name = docker_volume.jenkins_volume.name
   }
   volumes {
     host_path = "/var/run/docker.sock"
-    container_path = "/var/run/docker.sock"
+    container_path = "/tmp/docker.sock"
     read_only = true
   }
   ports {
@@ -78,7 +83,7 @@ resource "docker_container" "rproxy_container" {
 
 resource "docker_container" "jenkins_container" {
   name = "jenkins"
-  image = docker_image.jenkins_latest.id
+  image = docker_image.jenkins_latest.name
   restart = "always"
   volumes {
     container_path = "/var/jenkins_home"
@@ -96,7 +101,7 @@ resource "docker_container" "jenkins_container" {
 
 resource "docker_container" "transmission_container" {
   name = "transmission"
-  image = docker_image.transmission_latest.id
+  image = docker_image.transmission_latest.name
   restart = "always"
   volumes {
     container_path = "/config"

--- a/variables.tf
+++ b/variables.tf
@@ -1,19 +1,19 @@
 variable "domain_name" {
-  type = string
+  type        = string
   description = "Domain name for reverse proxy to use, e.g. example.com"
 }
 
 variable "docker_user" {
-  type = string
+  type        = string
   description = "User who has docker permissions on the remote host.  Passwordless SSH required."
 }
 
 variable "ssl_certs" {
-    type = string
-    description = "Location for ssl certs for nginx to use"
+  type        = string
+  description = "Location for ssl certs for nginx to use"
 }
 
 variable "transmission_download_storage" {
-    type = string
-    description = "Shared storage location for where transmission can put downloads"
+  type        = string
+  description = "Shared storage location for where transmission can put downloads"
 }


### PR DESCRIPTION
- Updated to standard HCL formatting
- Add read_only true/false tags to volumes
- Add dependencies to control container start order.  Sometimes when starting I would get an error that a container couldn't be started and that the api killed the request, but the container was actually there and running.  Adding the dependencies seems to have fixed this.